### PR TITLE
Api: return null for settings and statistics for 'get' request

### DIFF
--- a/src/services/common/services.common.api_service.js
+++ b/src/services/common/services.common.api_service.js
@@ -1,4 +1,4 @@
-import { ERRORS_DESCRIPTION } from './services.common.constants';
+import { ERRORS_DESCRIPTION, LINK_TYPE } from './services.common.constants';
 import { ApiError } from './services.common.api_service.helper';
 
 export default class ApiService {
@@ -7,7 +7,7 @@ export default class ApiService {
     this.token = token;
   }
 
-  async getResource({ url, hasToken }) {
+  async getResource({ url, hasToken, type = null }) {
     try {
       const res = await fetch(`${this.baseUrl}${url}`, {
         method: 'GET',
@@ -19,6 +19,12 @@ export default class ApiService {
         },
       });
       if (!res.ok) {
+        if (res.status === 404 && type === LINK_TYPE.Settings) {
+          return LINK_TYPE.Settings[404];
+        }
+        if (res.status === 404 && type === LINK_TYPE.Statictics) {
+          return LINK_TYPE.Statictics[404];
+        }
         this.getError(res.status, `Could not fetch: ${url}, API message: ${res.status} ${res.statusText}`);
       }
       return res.json();

--- a/src/services/common/services.common.constants.js
+++ b/src/services/common/services.common.constants.js
@@ -1,5 +1,5 @@
 const MAIN_API_URL = 'https://afternoon-falls-25894.herokuapp.com';
-const TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVlZTdhM2FjNDM5YzQ3MDAxN2M0ZTYzMCIsImlhdCI6MTU5MjM1MjMwMywiZXhwIjoxNTkyMzY2NzAzfQ.OakuZlZUBRUlZKtvRdvLl5-w7YLSMY2esQCjsPxImcs';
+const TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVlZWZhMGQzOTg5NmUxMDAxN2VlYTQwNCIsImlhdCI6MTU5MjkwMjQzOSwiZXhwIjoxNTkyOTE2ODM5fQ.xThNVUtI1QJI0LeYidkmIfhU2LwHX2M8sF6GLJQfreI';
 const ERRORS_DESCRIPTION = {
   400: '400: Bad Request',
   401: '401: Access Token Is Missing or Invalid',
@@ -18,6 +18,7 @@ const GET_RANDOM = (min, max) => {
   return Math.floor(Math.random() * (y - x + 1)) + x;
 };
 const MEDIA_LINK = 'https://raw.githubusercontent.com/caspercarver/rslang-data/master/';
+const LINK_TYPE = { Settings: { 404: null }, Statictics: { 404: null } };
 export {
-  MAIN_API_URL, TOKEN, GET_RANDOM, ERRORS_DESCRIPTION, MEDIA_LINK,
+  MAIN_API_URL, TOKEN, GET_RANDOM, ERRORS_DESCRIPTION, MEDIA_LINK, LINK_TYPE,
 };

--- a/src/services/main/endpoints/services.main.endpoints.settings.js
+++ b/src/services/main/endpoints/services.main.endpoints.settings.js
@@ -1,5 +1,5 @@
 import ApiService from '../../common/services.common.api_service';
-import { MAIN_API_URL, TOKEN } from '../../common/services.common.constants';
+import { MAIN_API_URL, TOKEN, LINK_TYPE } from '../../common/services.common.constants';
 
 export default class SettingsApi {
   constructor() {
@@ -7,8 +7,8 @@ export default class SettingsApi {
   }
 
   async getSettings({ userId }) {
-    const res = await this._apiService.getResource({ url: `/users/${userId}/settings`, hasToken: true });
-    return this._transformUserSettings(res);
+    const res = await this._apiService.getResource({ url: `/users/${userId}/settings`, hasToken: true, type: LINK_TYPE.Settings });
+    return (res) ? this._transformUserSettings(res) : res;
   }
 
   async updateSettings({ userId, wordsPerDay, optional = {} }) {

--- a/src/services/main/endpoints/services.main.endpoints.statistics.js
+++ b/src/services/main/endpoints/services.main.endpoints.statistics.js
@@ -1,5 +1,5 @@
 import ApiService from '../../common/services.common.api_service';
-import { MAIN_API_URL, TOKEN } from '../../common/services.common.constants';
+import { MAIN_API_URL, TOKEN, LINK_TYPE } from '../../common/services.common.constants';
 
 export default class StatisticsApi {
   constructor() {
@@ -7,8 +7,8 @@ export default class StatisticsApi {
   }
 
   async getStatictics({ userId }) {
-    const res = await this._apiService.getResource({ url: `/users/${userId}/statistics`, hasToken: true });
-    return this._transformUserStatistics(res);
+    const res = await this._apiService.getResource({ url: `/users/${userId}/statistics`, hasToken: true, type: LINK_TYPE.Statictics });
+    return res ? this._transformUserStatistics(res) : res;
   }
 
   async updateStatistics({ userId, learnedWords, optional = {} }) {

--- a/src/services/main/endpoints/services.main.endpoints.users.test.js
+++ b/src/services/main/endpoints/services.main.endpoints.users.test.js
@@ -65,6 +65,7 @@ describe('update user', () => {
     const res = await user.updateUser({
       id: auth.userId,
       email: newEmail,
+      password: userDefault.password
     });
     expect(res).toBeDefined();
     expect(res).toMatchObject({


### PR DESCRIPTION
_Проблема:_ для Settings и Statistics возвращается 404, если нет данных, но это не ошибка, как в случае поиска юзера с несуществующим id, просто для этого юзера не записывали настройки и статистику. 
_Решение:_ добавлен объект, в котором можно менять, что возвращается в случае 404 для этих запросов, я указала null, исключение не сгенерируется, **вернется null**.  
https://github.com/CasperCarver/rslang/blob/b57e3929cfeb33be0588eb6b9f2bbe8ddf1be727/src/services/common/services.common.constants.js#L21.

В основном методе я проверяю тип запроса и тип ответа 404. 
https://github.com/CasperCarver/rslang/blob/b57e3929cfeb33be0588eb6b9f2bbe8ddf1be727/src/services/common/services.common.api_service.js#L22

Если вам нужен объект, можете изменить на объект, 
`const LINK_TYPE = { Settings: { 404: { } }, Statictics: { 404: { } }; `
тогда в _transform нужно указать null (т.к. будет деструктуризация объекта и в отсутствующих ключах в значениях укажется undefind), тут как удобнее.
```
_transformUserSettings({ id, wordsPerDay, optional }) {
    return {
      id || null,
      wordsPerDay || null,
      optional: optional || null,
    };
```
Тогда в методе вместо null вернется  
 ```
     {
      id: null,
      wordsPerDay: null,
      optional: null,
 };
```
Возвращать null, думаю, проще.