### PR TITLE
Fix/ game savannah statistics

### DIFF
--- a/src/components/savannah/scss/components/finalcountdown.scss
+++ b/src/components/savannah/scss/components/finalcountdown.scss
@@ -5,6 +5,7 @@
   color: $color-dark-brown;
   justify-content: center;
   height: 100vh;
+  margin: 2rem;
 }
 
 .savannah__start_final_countdown_count {

--- a/src/components/savannah/services/savannah_game.js
+++ b/src/components/savannah/services/savannah_game.js
@@ -86,7 +86,9 @@ export class SavannahGame {
     });
     const answersBtns = document.querySelector('#js-savannah__answears');
     answersBtns.addEventListener('click', (e) => {
-      this.answerHandle(e.target);
+      if (e.target.classList.contains('savannah__answear') || e.target.classList.contains('savannah__answear_number')) {
+        this.answerHandle(e.target);
+      }
     });
   }
 

--- a/src/components/savannah/services/savannah_game.js
+++ b/src/components/savannah/services/savannah_game.js
@@ -141,16 +141,6 @@ export class SavannahGame {
   showLearningWord() {
     const wrongAnswers = this.staticticsRound.wrong.reduce((acc, word) => acc + getSavannahResultAnswer(this._transformAnswer(word)), '');
     const correctAnswers = this.staticticsRound.correct.reduce((acc, word) => acc + getSavannahResultAnswer(this._transformAnswer(word)), '');
-    mainStorage.addMiniGameResults({
-      miniGameName: MINI_GAMES_NAMES.SAVANNA,
-      isCorrect: true,
-      wordsDataArray: correctAnswers,
-    });
-    mainStorage.addMiniGameResults({
-      miniGameName: MINI_GAMES_NAMES.SAVANNA,
-      isCorrect: false,
-      wordsDataArray: wrongAnswers,
-    });
     const answersNode = document.querySelector('.savannah__start_final_answears');
     answersNode.innerHTML = null;
     answersNode.insertAdjacentHTML('beforeend', getSavannahCurrentWords(this.staticticsRound.wrong.length, this.staticticsRound.correct.length));
@@ -193,9 +183,19 @@ export class SavannahGame {
         answerNode.classList.add('savannah__answear_correct');
       }
       this.staticticsRound.correct.push(this.currentWord);
+      mainStorage.addMiniGameResult({
+        miniGameName: MINI_GAMES_NAMES.SAVANNA,
+        isCorrect: true,
+        wordData: this.currentWord,
+      });
       this.initGameLoop(isCorrectAnswer);
     } else {
       this.staticticsRound.wrong.push(this.currentWord);
+      mainStorage.addMiniGameResult({
+        miniGameName: MINI_GAMES_NAMES.SAVANNA,
+        isCorrect: false,
+        wordData: this.currentWord,
+      });
       if (answerNode) {
         answerNode.classList.add('savannah__answear_wrong');
       }


### PR DESCRIPTION
Исправила передачу изученных слов в мэйн компонент для раздела Статистика вместо массива по 1 объекту.

Исправила вёрстку в final contdown, чтобы слова "не прилипали" к краям экрана при мобильной версии.
![image](https://user-images.githubusercontent.com/51196040/87540405-528d0380-c6a8-11ea-81c2-cc7af3414db8.png)

UPDATE
Исправила проверку node при ответе, чтобы не выделялась вся область answers